### PR TITLE
Add files via upload

### DIFF
--- a/IPFS.sol
+++ b/IPFS.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.7.0 <0.9.0;
+
+contract IPFSCaller {
+    function storeDataOnIPFS(string memory data) public {
+        bytes32 ipfsHash = addDataToIPFS(data);
+        emit LogIPFSHash(ipfsHash);
+    }
+    
+    event LogIPFSHash(bytes32 ipfsHash);
+    
+    function addDataToIPFS(string memory data) private returns (bytes32) {
+        // Your code to send the data to IPFS and return the hash goes here.
+        // This is just an example and not a working implementation.
+        return 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef;
+    }
+}


### PR DESCRIPTION
The IPFSCaller contract is a Solidity contract for storing data on IPFS (InterPlanetary File System). The contract has a single public function storeDataOnIPFS which takes a string of data as input. The function then calls the private function addDataToIPFS which sends the data to IPFS and returns the hash of the stored data. The hash is emitted through the LogIPFSHash event. The code for sending the data to IPFS is just an example and not a working implementation.